### PR TITLE
Allow nested Models to be created with API spec

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -336,7 +336,7 @@ function addMethod(app, callback, spec) {
   var currentMethod = spec.method.toLowerCase();
   if (allowedMethods.indexOf(currentMethod)>-1) {
     if(currentMethod == 'delete') currentMethod = 'del';
-    app[currentMethod](fullPath, function(req,res, next) {
+    app[currentMethod](fullPath, function swaggerAddMethod(req,res, next) {
       exports.setHeaders(res);
 
       // todo: needs to do smarter matching against the defined paths


### PR DESCRIPTION
Only the 'responseClass' was added to the models object of the swagger json, even if its referenced objects were defined. So swagger-ui could not display the ref'd objects (only their names). New 'spec' property is 'otherModels', which is an array of other Model names (strings). It is optional, so will not affect other working versions. Models are only added once (as per current code).

Used like this: 

```
{
...
"responseClass" : "PersonInfo",
"otherModels" : ["PersonContact", "PersonOther" ],
...
}
```
